### PR TITLE
fix(cmake): set CMAKE_EXPERIMENTAL_CXX_IMPORT_STD unconditionally

### DIFF
--- a/.github/workflows/medical-validation.yml
+++ b/.github/workflows/medical-validation.yml
@@ -164,7 +164,7 @@ jobs:
       run: |
         cmake -B build -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_CXX_COMPILER=g++-15 \
+          -DCMAKE_CXX_COMPILER=g++ \
           -DSPECLAB_BUILD_EXAMPLES=ON \
           -DSPECLAB_ISO14971_VALIDATION=ON
         cmake --build build --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,11 @@ cmake_minimum_required(VERSION 4.0.0)
 
 # CRITICAL: Must be the first thing after cmake_minimum_required for toolchain detection
 # Official UUID for CMake 4.0.3 import std support
-# NOTE: enabling CMAKE_EXPERIMENTAL_CXX_IMPORT_STD unconditionally can cause CMake to synthesize
-# a __CMAKE::CXX23 target that references non-existent 'std.cc' sources on some GCC/libstdc++ setups.
-# Guard it: enable explicitly for MSVC where import std handling is stable; for GNU we use the
-# manual `build_std_module` custom target defined later in this file.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-    set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "d0edc3af-4c50-42ea-a356-e2862fe7a444")
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    message(STATUS "Skipping global CMAKE_EXPERIMENTAL_CXX_IMPORT_STD for GNU - using manual build_std_module target")
-else()
-    # Leave unset for other compilers
-    set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "")
-endif()
+# Set unconditionally, before project(). It cannot be guarded on CMAKE_CXX_COMPILER_ID here:
+# that variable is populated by compiler detection inside project(), so before that call it is
+# empty and any if/elseif on it takes the else branch - which is how this ended up disabling
+# `import std` for every compiler, MSVC included.
+set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "d0edc3af-4c50-42ea-a356-e2862fe7a444")
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
## The bug

`CMakeLists.txt` guarded `CMAKE_EXPERIMENTAL_CXX_IMPORT_STD` on `CMAKE_CXX_COMPILER_ID`, before `project()`:

```cmake
if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
    set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "d0edc3af-…")
elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
    message(STATUS "Skipping global CMAKE_EXPERIMENTAL_CXX_IMPORT_STD for GNU …")
else()
    set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "")
endif()
```

`CMAKE_CXX_COMPILER_ID` is populated by compiler detection **inside `project()`**. Before that call it is empty, so the chain always fell through to `else()` and set the variable to `""` — **disabling `import std` for every compiler, MSVC included**, not just GNU.

The comment directly above it is the reason it can't work there: *"Must be the first thing after `cmake_minimum_required` for toolchain detection"*. The position that makes the setting effective is exactly the position where the compiler is not yet known.

## The symptom

Every module interface failed on its first line:

```
include/speclab/core/TestResult.cppm:7:1: fatal error: unknown compiled module interface: no such module
    7 | import std;
```

…because no `__CMAKE::CXX23` target was ever synthesised. The configure log said so plainly, and the diagnostic was already in the file:

```
-- __CMAKE::CXX23 target NOT available - import std; will not work
```

## The fix

Set it unconditionally before `project()`, which is what the UUID mechanism expects and what consumers of this pattern do.

## Verified

GCC 15.2.0, CMake 4.0.3, Ninja, clean build directory with `ccache` disabled:

| | before | after |
|---|---|---|
| `__CMAKE::CXX23` | NOT available | **available** |
| modules compiled | **0** of 13 | **12** of 13 |

The twelve: `core.assertions`, `core.functionalapi`, `core.requirementapi`, `core.requirements`, `core.testcase`, `core.testresult`, `core.testsuite`, `medical.compliancevalidator`, `medical.functionalapi`, `medical.medicaltestcase`, `reporters.consolereporter`, `reporters.reporter`.

## One module still fails, and it is not this bug

`speclab.runners.testrunner` fails with a **GCC 15 defect in std-module deserialisation**, which this change does not address and cannot:

```
speclab.core.testsuite: error: failed to read compiled module cluster 371: Bad file data
include/speclab/runners/TestRunner.cppm:32:26: fatal error: failed to load pendings for 'std::_Sp_counted_ptr_inplace'
```

Worth being precise about the cause, because it does **not** look like a SpecLab problem: there is no `make_shared` anywhere under `include/`, so `std::_Sp_counted_ptr_inplace` is reaching the BMI transitively through `import std;`. GCC is failing to round-trip part of the std module's `shared_ptr` machinery through `speclab.core.testsuite`'s serialised interface. Reproducible on a clean build with `ccache` disabled, so it is not a stale `.gcm`.

I have not filed this as a separate issue in case you would rather track it inside this PR — happy to split it out.

## Why I ran into this

I'm adopting SpecLab as the BDD framework for [MduX](https://github.com/ambroise-leclerc/MduX) (issue #108's territory — it supersedes ADR-002's never-implemented Catch2 selection). MduX's CI covers MSVC, GCC 15 and GCC 16, so SpecLab building under GCC is a prerequisite. With this fix the twelve modules MduX actually needs — the functional BDD API, the requirement API and the assertions — all compile; the runner is not on that path, since the examples import specific submodules rather than the `speclab` umbrella.

I have not touched `build_std_module`. With this change it is redundant on GCC (it precompiles *header units*, which give `import <vector>;`, not `import std;`), but removing it is a separate judgement call and belongs in its own change.
