### PR TITLE
Add commercial dual licensing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @ambroise-leclerc
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Summary
+
+Describe the change and why it is needed.
+
+## Invitation and contributor agreement
+
+- [ ] I was invited by a maintainer to contribute this change.
+- [ ] I accepted the repository's [Contributor Licence Agreement](../CLA.md) in the GitHub issue identified below.
+
+Invitation / CLA issue: #
+
+## Verification
+
+List the checks performed and their results.
+

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,61 @@
+# Contributor Licence Agreement
+
+This Contributor Licence Agreement (the **Agreement**) applies to invited contributions to this
+repository.
+
+**Project Steward:** Ambroise Leclerc.  
+**You:** the individual or legal entity accepting this Agreement.  
+**Contribution:** any original work of authorship that You intentionally submit for inclusion in
+this repository after accepting this Agreement.
+
+## 1. Copyright licence
+
+You retain ownership of Your Contribution. You grant the Project Steward a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable copyright licence to reproduce, prepare derivative works
+of, publicly display, publicly perform, use, distribute, sublicense, and relicense Your
+Contribution, in source or object form, under EUPL-1.2 and under alternative commercial terms.
+
+## 2. Patent licence
+
+You grant the Project Steward and recipients of software distributed by the Project Steward a
+perpetual, worldwide, non-exclusive, royalty-free patent licence to make, have made, use, offer to
+sell, sell, import, and otherwise transfer Your Contribution, where that licence applies only to
+patent claims You can license that are necessarily infringed by Your Contribution alone or by its
+combination with the repository at the time it is submitted.
+
+If You initiate patent litigation alleging that the repository or a Contribution incorporated in
+it infringes a patent, the patent licences granted by You under this section terminate as of the
+date the litigation is filed.
+
+## 3. Your assurances
+
+You represent that:
+
+- You are legally entitled to grant the rights in this Agreement;
+- if an employer or another entity owns relevant rights, You have obtained its authorisation or
+  that entity has separately accepted an appropriate agreement;
+- Your Contribution is original, except for third-party material that You clearly identify along
+  with its source and licence; and
+- You will notify the Project Steward if any statement above becomes inaccurate.
+
+## 4. No support or warranty
+
+You are not required to provide support for Your Contribution. Unless separately agreed in
+writing, Your Contribution is provided without warranty.
+
+## 5. Successor project steward
+
+The Project Steward may assign this Agreement and the rights it grants to a legal entity that he
+controls and that becomes the steward of Compliatory, provided that entity assumes this
+Agreement's obligations and accepted Contributions remain available under EUPL-1.2.
+
+## 6. Acceptance
+
+You accept this Agreement by replying **`I agree`** to the GitHub invitation or CLA-record issue
+identified by the maintainer before Your first Contribution is merged. The maintainer records the
+acceptance by GitHub account and date. A pull request alone does not constitute acceptance.
+
+This Agreement is governed by French law. Contributors acting for a company may be asked for a
+separate corporate agreement. The Project Steward should obtain legal review before relying on
+this Agreement for commercial relicensing.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## Invitation-only policy
+
+This project accepts code and documentation contributions only from collaborators explicitly
+invited by a maintainer. Opening an issue or pull request does not constitute an invitation, and
+unsolicited pull requests may be closed without review.
+
+Before contributing, an invited collaborator must accept the [Contributor Licence
+Agreement](CLA.md) in the GitHub issue designated by the maintainer. Only collaborators with
+repository access may submit changes for review. Every change remains subject to maintainer review;
+an invitation does not guarantee merge.
+
+Invited contributors must follow [AGENTS.md](AGENTS.md), keep changes focused, and report the exact
+checks they ran.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,25 @@
+# Licensing
+
+This project is available under a dual-licensing model.
+
+## Open-source licence
+
+Unless a separate written agreement applies, the repository is provided under the
+[European Union Public Licence 1.2](LICENSE) (`EUPL-1.2`).
+
+## Commercial licence
+
+Alternative commercial terms may be available from the project steward for organisations that
+need terms different from EUPL-1.2, including proprietary distribution or integration terms,
+contractual support, maintenance commitments, or warranties defined by contract.
+
+A commercial licence is granted only through a separate written agreement. The presence of this
+notice does not itself grant commercial-licence rights.
+
+Contact the project steward by opening a GitHub issue that contains no confidential information.
+
+## Contributions
+
+Contributions are accepted by invitation only and are governed by
+[the Contributor Licence Agreement](CLA.md). See [the contribution policy](CONTRIBUTING.md).
+

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -16,10 +16,15 @@ contractual support, maintenance commitments, or warranties defined by contract.
 A commercial licence is granted only through a separate written agreement. The presence of this
 notice does not itself grant commercial-licence rights.
 
+## Earlier revisions
+
+Commits, tags, and releases published before the EUPL-1.2 licensing change remain available under
+the licence stated in the corresponding revision. This change governs the repository contents from
+the commit that adopts it onward; it does not retroactively alter the terms of earlier releases.
+
 Contact the project steward by opening a GitHub issue that contains no confidential information.
 
 ## Contributions
 
 Contributions are accepted by invitation only and are governed by
 [the Contributor Licence Agreement](CLA.md). See [the contribution policy](CONTRIBUTING.md).
-

--- a/README.md
+++ b/README.md
@@ -476,7 +476,8 @@ clang-tidy -p build include/**/*.cppm
 
 ## License
 
-This project is licensed under the European Union Public License v1.2 - see the [LICENSE](LICENSE) file for details.
+This project is available under the [European Union Public Licence 1.2](LICENSE), or under separate
+commercial terms. See [LICENSING.md](LICENSING.md).
 
 ## Medical Device Notice
 


### PR DESCRIPTION
## What changed

- adopts EUPL-1.2 as the repository's public open-source licence;
- documents the availability of separate commercial terms;
- adds a contributor licence agreement supporting the dual-licensing model;
- limits accepted contributions to invited collaborators;
- adds a pull-request attestation and CODEOWNERS coverage.

## Legal merge gate

**Do not merge this draft until every contributor identified in the linked relicensing-consent issue has explicitly agreed, or the affected contributions have been removed or independently rewritten.**

The public EUPL licence and commercial licensing are alternatives; commercial rights exist only through a separate written agreement.

## Verification

- confirmed that the EUPL-1.2 text matches the existing EUPL text used by SpecLab;
- checked the diff for whitespace errors;
- searched the repository for residual references to the previous licence;
- validated Cargo metadata where applicable.

No product code or regulatory claim is changed.

Relicensing consent: #13.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added licensing information covering the European Union Public Licence 1.2 and separate commercial terms.
  - Updated the README with links to licensing resources.
  - Added contributor guidelines, including contribution requirements and submission expectations.
  - Added a Contributor Licence Agreement outlining applicable legal terms.
  - Added a pull request template to standardize change summaries and verification details.
- **Chores**
  - Defined default repository code ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->