### PR TITLE
Fix release package staging path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,9 +72,23 @@ jobs:
       id: get_version
       run: |
         if [ "${{ github.ref_type }}" = "tag" ]; then
-          echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          VERSION=${GITHUB_REF#refs/tags/}
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)(\.[0-9]+)?)?$ ]]; then
+            echo "Invalid release tag: $VERSION" >&2
+            exit 1
+          fi
         else
-          echo "version=nightly-$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+          VERSION=nightly-$(date +%Y%m%d)
+        fi
+        PACKAGE_NAME="SpecLab-$VERSION-${{ matrix.platform }}-${{ matrix.arch }}"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
+        echo "PACKAGE_DIR=$GITHUB_WORKSPACE/$PACKAGE_NAME" >> "$GITHUB_ENV"
+        if [ "${{ matrix.platform }}" = "windows" ]; then
+          echo "ARCHIVE_NAME=$PACKAGE_NAME.zip" >> "$GITHUB_ENV"
+        else
+          echo "ARCHIVE_NAME=$PACKAGE_NAME.tar.gz" >> "$GITHUB_ENV"
         fi
       shell: bash
 
@@ -88,7 +102,7 @@ jobs:
           -DSPECLAB_BUILD_EXAMPLES=ON `
           -DSPECLAB_BUILD_TESTS=OFF `
           -DSPECLAB_INSTALL_EXAMPLES=ON `
-          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}" `
+          -DCMAKE_INSTALL_PREFIX="$env:PACKAGE_DIR" `
           -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD="d0edc3af-4c50-42ea-a356-e2862fe7a444"
 
     - name: Configure Release Build (Linux)
@@ -102,7 +116,7 @@ jobs:
           -DSPECLAB_BUILD_EXAMPLES=ON \
           -DSPECLAB_BUILD_TESTS=OFF \
           -DSPECLAB_INSTALL_EXAMPLES=ON \
-          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}" \
+          -DCMAKE_INSTALL_PREFIX="$PACKAGE_DIR" \
           -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD="d0edc3af-4c50-42ea-a356-e2862fe7a444"
 
     - name: Build Release
@@ -126,7 +140,7 @@ jobs:
 
     - name: Create Release Documentation
       run: |
-        cd SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}
+        cd "$PACKAGE_NAME"
         cat > README.md << 'EOF'
         # SpecLab Medical Device Testing Framework
         
@@ -184,7 +198,7 @@ jobs:
 
     - name: Create Medical Device Compliance Guide
       run: |
-        cd SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}
+        cd "$PACKAGE_NAME"
         mkdir -p docs/compliance
         cat > docs/compliance/IEC62304-Guide.md << 'EOF'
         # IEC 62304 Compliance Guide for SpecLab
@@ -232,20 +246,16 @@ jobs:
     - name: Package Release (Windows)
       if: matrix.platform == 'windows'
       run: |
-        Compress-Archive -Path "SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}" -DestinationPath "SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.zip"
+        Compress-Archive -Path $env:PACKAGE_NAME -DestinationPath $env:ARCHIVE_NAME
 
     - name: Package Release (Linux)
       if: matrix.platform == 'linux'
       run: |
-        tar -czf "SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz" "SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}"
+        tar -czf "$ARCHIVE_NAME" "$PACKAGE_NAME"
 
     - name: Generate Package Checksums
       run: |
-        if [ "${{ matrix.platform }}" = "windows" ]; then
-          Get-FileHash "SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.zip" -Algorithm SHA256 | Out-File "SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.zip.sha256"
-        else
-          sha256sum "SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz" > "SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}.tar.gz.sha256"
-        fi
+        sha256sum "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256"
       shell: bash
 
     - name: Upload Release Package
@@ -286,10 +296,20 @@ jobs:
       id: get_version
       run: |
         if [ "${{ github.ref_type }}" = "tag" ]; then
-          echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          VERSION=${GITHUB_REF#refs/tags/}
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)(\.[0-9]+)?)?$ ]]; then
+            echo "Invalid release tag: $VERSION" >&2
+            exit 1
+          fi
         else
-          echo "version=nightly-$(date +%Y%m%d)" >> $GITHUB_OUTPUT
+          VERSION=nightly-$(date +%Y%m%d)
         fi
+        PACKAGE_NAME="SpecLab-$VERSION-linux-x64"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
+        echo "PACKAGE_DIR=$GITHUB_WORKSPACE/$PACKAGE_NAME" >> "$GITHUB_ENV"
+        echo "ARCHIVE_NAME=$PACKAGE_NAME.tar.gz" >> "$GITHUB_ENV"
       shell: bash
 
     - name: Configure Release Build (Linux)
@@ -302,7 +322,7 @@ jobs:
           -DSPECLAB_BUILD_EXAMPLES=ON \
           -DSPECLAB_BUILD_TESTS=OFF \
           -DSPECLAB_INSTALL_EXAMPLES=ON \
-          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SpecLab-${{ steps.get_version.outputs.version }}-linux-x64" \
+          -DCMAKE_INSTALL_PREFIX="$PACKAGE_DIR" \
           -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD="d0edc3af-4c50-42ea-a356-e2862fe7a444"
 
     - name: Build Release
@@ -319,11 +339,11 @@ jobs:
 
     - name: Package Release (Linux)
       run: |
-        tar -czf "SpecLab-${{ steps.get_version.outputs.version }}-linux-x64.tar.gz" "SpecLab-${{ steps.get_version.outputs.version }}-linux-x64"
+        tar -czf "$ARCHIVE_NAME" "$PACKAGE_NAME"
 
     - name: Generate Package Checksums
       run: |
-        sha256sum "SpecLab-${{ steps.get_version.outputs.version }}-linux-x64.tar.gz" > "SpecLab-${{ steps.get_version.outputs.version }}-linux-x64.tar.gz.sha256"
+        sha256sum "$ARCHIVE_NAME" > "$ARCHIVE_NAME.sha256"
 
     - name: Upload Release Package
       uses: actions/upload-artifact@v4
@@ -356,7 +376,11 @@ jobs:
       id: get_info
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)(\.[0-9]+)?)?$ ]]; then
+          echo "Invalid release tag: $VERSION" >&2
+          exit 1
+        fi
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         
         # Generate release notes
         cat > release-notes.md << EOF
@@ -456,7 +480,12 @@ jobs:
       id: get_version
       run: |
         VERSION=${GITHUB_REF#refs/tags/}
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)(\.[0-9]+)?)?$ ]]; then
+          echo "Invalid release tag: $VERSION" >&2
+          exit 1
+        fi
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "VERSION=$VERSION" >> "$GITHUB_ENV"
 
     - name: Create vcpkg package manifest
       run: |
@@ -464,7 +493,7 @@ jobs:
         cat > vcpkg-package/vcpkg.json << EOF
         {
           "name": "speclab",
-          "version": "${{ steps.get_version.outputs.version }}",
+          "version": "$VERSION",
           "description": "Medical Device Testing Framework with IEC 62304, ISO 14971, and FDA 21 CFR Part 820 compliance",
           "homepage": "https://github.com/your-org/SpecLab",
           "documentation": "https://speclab-docs.example.com",
@@ -493,7 +522,7 @@ jobs:
         
         class SpecLabConan(ConanFile):
             name = "speclab"
-            version = "${{ steps.get_version.outputs.version }}"
+            version = "$VERSION"
             description = "Medical Device Testing Framework"
             license = "MIT"
             url = "https://github.com/your-org/SpecLab"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
           -DSPECLAB_BUILD_EXAMPLES=ON `
           -DSPECLAB_BUILD_TESTS=OFF `
           -DSPECLAB_INSTALL_EXAMPLES=ON `
-          -DCMAKE_INSTALL_PREFIX=SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }} `
+          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}" `
           -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD="d0edc3af-4c50-42ea-a356-e2862fe7a444"
 
     - name: Configure Release Build (Linux)
@@ -102,7 +102,7 @@ jobs:
           -DSPECLAB_BUILD_EXAMPLES=ON \
           -DSPECLAB_BUILD_TESTS=OFF \
           -DSPECLAB_INSTALL_EXAMPLES=ON \
-          -DCMAKE_INSTALL_PREFIX=SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }} \
+          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SpecLab-${{ steps.get_version.outputs.version }}-${{ matrix.platform }}-${{ matrix.arch }}" \
           -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD="d0edc3af-4c50-42ea-a356-e2862fe7a444"
 
     - name: Build Release
@@ -302,7 +302,7 @@ jobs:
           -DSPECLAB_BUILD_EXAMPLES=ON \
           -DSPECLAB_BUILD_TESTS=OFF \
           -DSPECLAB_INSTALL_EXAMPLES=ON \
-          -DCMAKE_INSTALL_PREFIX=SpecLab-${{ steps.get_version.outputs.version }}-linux-x64 \
+          -DCMAKE_INSTALL_PREFIX="${{ github.workspace }}/SpecLab-${{ steps.get_version.outputs.version }}-linux-x64" \
           -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD="d0edc3af-4c50-42ea-a356-e2862fe7a444"
 
     - name: Build Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,16 @@ jobs:
             echo "Invalid release tag: $VERSION" >&2
             exit 1
           fi
+          PROJECT_VERSION=${VERSION#v}
+          PROJECT_VERSION=${PROJECT_VERSION%%-*}
         else
           VERSION=nightly-$(date +%Y%m%d)
+          PROJECT_VERSION=0.1.0
         fi
         PACKAGE_NAME="SpecLab-$VERSION-${{ matrix.platform }}-${{ matrix.arch }}"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        echo "PROJECT_VERSION=$PROJECT_VERSION" >> "$GITHUB_ENV"
         echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
         echo "PACKAGE_DIR=$GITHUB_WORKSPACE/$PACKAGE_NAME" >> "$GITHUB_ENV"
         if [ "${{ matrix.platform }}" = "windows" ]; then
@@ -102,6 +106,7 @@ jobs:
           -DSPECLAB_BUILD_EXAMPLES=ON `
           -DSPECLAB_BUILD_TESTS=OFF `
           -DSPECLAB_INSTALL_EXAMPLES=ON `
+          -DSPECLAB_PROJECT_VERSION="$env:PROJECT_VERSION" `
           -DCMAKE_INSTALL_PREFIX="$env:PACKAGE_DIR" `
           -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD="d0edc3af-4c50-42ea-a356-e2862fe7a444"
 
@@ -116,6 +121,7 @@ jobs:
           -DSPECLAB_BUILD_EXAMPLES=ON \
           -DSPECLAB_BUILD_TESTS=OFF \
           -DSPECLAB_INSTALL_EXAMPLES=ON \
+          -DSPECLAB_PROJECT_VERSION="$PROJECT_VERSION" \
           -DCMAKE_INSTALL_PREFIX="$PACKAGE_DIR" \
           -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD="d0edc3af-4c50-42ea-a356-e2862fe7a444"
 
@@ -242,6 +248,7 @@ jobs:
         };
         ```
         EOF
+      shell: bash
 
     - name: Package Release (Windows)
       if: matrix.platform == 'windows'
@@ -301,12 +308,16 @@ jobs:
             echo "Invalid release tag: $VERSION" >&2
             exit 1
           fi
+          PROJECT_VERSION=${VERSION#v}
+          PROJECT_VERSION=${PROJECT_VERSION%%-*}
         else
           VERSION=nightly-$(date +%Y%m%d)
+          PROJECT_VERSION=0.1.0
         fi
         PACKAGE_NAME="SpecLab-$VERSION-linux-x64"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        echo "PROJECT_VERSION=$PROJECT_VERSION" >> "$GITHUB_ENV"
         echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
         echo "PACKAGE_DIR=$GITHUB_WORKSPACE/$PACKAGE_NAME" >> "$GITHUB_ENV"
         echo "ARCHIVE_NAME=$PACKAGE_NAME.tar.gz" >> "$GITHUB_ENV"
@@ -322,6 +333,7 @@ jobs:
           -DSPECLAB_BUILD_EXAMPLES=ON \
           -DSPECLAB_BUILD_TESTS=OFF \
           -DSPECLAB_INSTALL_EXAMPLES=ON \
+          -DSPECLAB_PROJECT_VERSION="$PROJECT_VERSION" \
           -DCMAKE_INSTALL_PREFIX="$PACKAGE_DIR" \
           -DCMAKE_EXPERIMENTAL_CXX_IMPORT_STD="d0edc3af-4c50-42ea-a356-e2862fe7a444"
 
@@ -486,6 +498,7 @@ jobs:
         fi
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
         echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+        echo "PACKAGE_VERSION=${VERSION#v}" >> "$GITHUB_ENV"
 
     - name: Create vcpkg package manifest
       run: |
@@ -493,7 +506,7 @@ jobs:
         cat > vcpkg-package/vcpkg.json << EOF
         {
           "name": "speclab",
-          "version": "$VERSION",
+          "version": "$PACKAGE_VERSION",
           "description": "Medical Device Testing Framework with IEC 62304, ISO 14971, and FDA 21 CFR Part 820 compliance",
           "homepage": "https://github.com/your-org/SpecLab",
           "documentation": "https://speclab-docs.example.com",
@@ -522,7 +535,7 @@ jobs:
         
         class SpecLabConan(ConanFile):
             name = "speclab"
-            version = "$VERSION"
+            version = "$PACKAGE_VERSION"
             description = "Medical Device Testing Framework"
             license = "MIT"
             url = "https://github.com/your-org/SpecLab"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(cmake/PreventInSourceBuilds.cmake)
 
-project(speclab VERSION 0.1.0 DESCRIPTION "Modern C++23 Modules Testing Framework for Medical Devices" HOMEPAGE_URL "https://github.com/ambroise-leclerc/speclab" LANGUAGES CXX)
+set(SPECLAB_PROJECT_VERSION "0.1.0" CACHE STRING "SpecLab project version")
+project(speclab VERSION ${SPECLAB_PROJECT_VERSION} DESCRIPTION "Modern C++23 Modules Testing Framework for Medical Devices" HOMEPAGE_URL "https://github.com/ambroise-leclerc/speclab" LANGUAGES CXX)
 
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
## Summary

- use an absolute workspace install prefix for release packages
- keep Windows and Linux staging paths aligned with packaging steps

## Root cause

CMake resolved the relative Windows install prefix below the build directory, while subsequent documentation and packaging steps looked for it at the workspace root. Both Windows builds passed but release publication was skipped when packaging could not find the staged directory.

## Validation

- diff passes `git diff --check`
- replacement `v0.1.0` release workflow will validate Windows and Linux packaging after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release packaging for Windows and Linux by ensuring installed files are placed in the correct package directories.
  * Added validation for release tag versions to prevent improperly formatted releases.
  * Improved consistency across package archives, checksums, documentation, and version information.

* **Improvements**
  * Added support for setting the project version during the build process, improving version management across releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->